### PR TITLE
Fix async run' test

### DIFF
--- a/src/Test/Spec/Reporter/Xunit.purs
+++ b/src/Test/Spec/Reporter/Xunit.purs
@@ -1,7 +1,6 @@
 module Test.Spec.Reporter.Xunit
        ( xunitReporter
        , defaultOptions
-       , encodeSuite
        ) where
 
 import Prelude

--- a/src/Test/Spec/Reporter/Xunit.purs
+++ b/src/Test/Spec/Reporter/Xunit.purs
@@ -1,6 +1,7 @@
 module Test.Spec.Reporter.Xunit
        ( xunitReporter
        , defaultOptions
+       , encodeSuite
        ) where
 
 import Prelude


### PR DESCRIPTION
Since the test suite's `run` functions don't return Aff, we cannot await
its result in the XunitSpec tests. To get around that we can use
`runSpec'` which does return Aff. We're not, however, testing that the
suite actually prints the correct value.