### PR TITLE
Simplify the tests and examples by using the new runSpec' function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,11 @@ module Main where
 
 import Prelude
 
-import Data.Identity (Identity(..))
-import Data.Newtype (un)
 import Test.Spec.Reporter.Xunit (defaultOptions, xunitReporter)
-import Test.Spec.Runner (defaultConfig, runSpecT)
+import Test.Spec.Runner (defaultConfig, runSpec')
 
 main =
-  void $ un Identity $ runSpecT defaultConfig [ xunitReporter { indentation: 2, outputPath: "output/test.xml" } ] do
+  runSpec' defaultConfig [ xunitReporter { indentation: 2, outputPath: "output/test.xml" } ] do
     ...
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "output"
   ],
   "dependencies": {
-    "purescript-spec": "^4.0.0",
+    "purescript-spec": "^4.0.1",
     "purescript-node-fs-aff": "^6.0.0",
     "purescript-transformers": "^4.1.0"
   },

--- a/test/Test/Spec/Reporter/XunitSpec.purs
+++ b/test/Test/Spec/Reporter/XunitSpec.purs
@@ -2,15 +2,13 @@ module Test.Spec.Reporter.XunitSpec where
 
 import Prelude
 
-import Data.Identity (Identity(..))
-import Data.Newtype (un)
 import Node.Encoding (Encoding(UTF8))
 import Node.FS.Aff (readTextFile, unlink)
 import Test.Spec (Spec, it, describe)
 import Test.Spec.Assertions (fail)
 import Test.Spec.Assertions.String (shouldContain)
 import Test.Spec.Reporter.Xunit (defaultOptions, xunitReporter)
-import Test.Spec.Runner (defaultConfig, runSpecT)
+import Test.Spec.Runner (defaultConfig, runSpec')
 
 xunitSpec :: Spec Unit
 xunitSpec = do
@@ -34,7 +32,7 @@ xunitSpec = do
     runXunit spec = do
       let config = defaultConfig { exit = false }
           path = "output/test.tmp.xml"
-      void $ un Identity $ runSpecT config [xunitReporter $ defaultOptions { outputPath = path }] spec
+      runSpec' config [xunitReporter $ defaultOptions { outputPath = path }] spec
       contents <- readTextFile UTF8 path
       unlink path
       pure contents


### PR DESCRIPTION
This is a follow-on to https://github.com/purescript-spec/purescript-spec-reporter-xunit/pull/7